### PR TITLE
Update runtime to 24.08>25.08 and more

### DIFF
--- a/com.pikatorrent.PikaTorrent.yml
+++ b/com.pikatorrent.PikaTorrent.yml
@@ -1,6 +1,6 @@
 app-id: com.pikatorrent.PikaTorrent
 runtime: org.freedesktop.Platform
-runtime-version: "24.08"
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 command: pikatorrent
 finish-args:
@@ -15,24 +15,56 @@ finish-args:
   - --talk-name=org.kde.StatusNotifierWatcher
   # To check connectivity
   - --system-talk-name=org.freedesktop.NetworkManager
+cleanup:
+  - /include
+  - /lib/girepository-1.0
+  - /lib/pkgconfig
+  - /share/bash-completion
+  - /share/doc
+  - /share/fish
+  - /share/gir-1.0
+  - /share/zsh
+  - "*.la"
+  - "*.a"
+
 modules:
-  - name: PikaTorrent
-    buildsystem: simple
-    build-commands:
-      - mv pikatorrent /app/pikatorrent
-      - mkdir -p /app/bin
-      - ln -s /app/pikatorrent/pikatorrent /app/bin/pikatorrent
-    post-install:
-      - install -Dm644 com.pikatorrent.PikaTorrent.desktop ${FLATPAK_DEST}/share/applications/com.pikatorrent.PikaTorrent.desktop
-      - install -Dm644 com.pikatorrent.PikaTorrent.metainfo.xml ${FLATPAK_DEST}/share/metainfo/com.pikatorrent.PikaTorrent.metainfo.xml
-      # TODO: Use svg
-      - install -Dm644 icon.png ${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/${FLATPAK_ID}.png
+  - shared-modules/libayatana-appindicator/libayatana-appindicator-gtk3.json
+
+  - name: libmpv
+    buildsystem: meson
+    config-opts:
+      - -Dlibmpv=true
+      - -Dbuildtype=release
+      - -Dbuild-date=false
+      - -Dmanpage-build=disabled
+      - -Dvulkan=enabled
+    cleanup:
+      - /share/icons/
+    sources:
+      - type: git
+        url: https://github.com/mpv-player/mpv.git
+        tag: v0.41.0
+        commit: 41f6a645068483470267271e1d09966ca3b9f413
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$
     modules:
-      - shared-modules/libayatana-appindicator/libayatana-appindicator-gtk3.json
+      # MPV dependencies
+      - name: libplacebo
+        buildsystem: meson
+        config-opts:
+          - -Dvulkan=enabled
+          - -Dshaderc=enabled
+        sources:
+          - type: git
+            url: https://github.com/haasn/libplacebo.git
+            tag: v7.360.1
+            commit: cee9b076f2c63104ccfd497fa79c39a867293ec4
+            x-checker-data:
+              type: git
+              tag-pattern: ^v([\d.]+)$
+
       - name: libass
-        cleanup:
-          - /include
-          - /lib/pkgconfig
         config-opts:
           - --disable-static
           - --enable-asm
@@ -47,72 +79,15 @@ modules:
               type: git
               tag-pattern: ^(\d\.\d{1,3}\.\d{1,2})$
 
-      - name: libplacebo
-        buildsystem: meson
-        config-opts:
-          - -Dvulkan=enabled
-          - -Dshaderc=enabled
-        cleanup:
-          - /include
-          - /lib/pkgconfig
-        sources:
-          - type: git
-            url: https://github.com/haasn/libplacebo.git
-            tag: v7.349.0
-            commit: 1fd3c7bde7b943fe8985c893310b5269a09b46c5
-            # fix from https://github.com/flathub/io.mpv.Mpv/commit/b3001a27d9f7f09edee2c6bd6de25237f2f468b4
-            # Disabled libplacebo update above v7.349.0, though it compiles, but videos do not play/work with freedesktop sdk 24.08 due to vulkan 1.0; perhaps 25.08 may work.
-            #x-checker-data:
-            #  type: git
-            #  tag-pattern: ^v([\d.]+)$
-
-      - name: ffmpeg
-        cleanup:
-          - /include
-          - /lib/pkgconfig
-          - /share/ffmpeg/examples
-        config-opts:
-          - --disable-doc
-          - --disable-programs"
-          - --disable-encoders"
-          - --disable-debug
-          - --disable-doc
-          - --disable-static
-          - --enable-gnutls
-          - --enable-gpl
-          - --enable-version3
-          - --enable-shared
-          - --enable-libass
-          - --enable-vulkan
-
-        sources:
-          - type: git
-            url: https://github.com/FFmpeg/FFmpeg.git
-            commit: 894da5ca7d742e4429ffb2af534fcda0103ef593
-            tag: n8.0.1
-            x-checker-data:
-              type: git
-              tag-pattern: ^n([\d.]{3,7})$
-
-      - name: libmpv
-        buildsystem: meson
-        config-opts:
-          - -Dlibmpv=true
-          - --buildtype=release
-          - -Dbuild-date=false
-          - -Dmanpage-build=disabled
-          - -Dvulkan=enabled
-        cleanup:
-          - /include
-          - /lib/pkgconfig
-        sources:
-          - type: git
-            url: https://github.com/mpv-player/mpv.git
-            tag: v0.41.0
-            commit: 41f6a645068483470267271e1d09966ca3b9f413
-            x-checker-data:
-              type: git
-              tag-pattern: ^v([\d.]+)$
+  - name: PikaTorrent
+    buildsystem: simple
+    build-commands:
+      - mv pikatorrent /app/pikatorrent
+      - mkdir -p /app/bin
+      - ln -s /app/pikatorrent/pikatorrent /app/bin/pikatorrent
+      - install -Dm644 app/linux/packaging/${FLATPAK_ID}.desktop -t ${FLATPAK_DEST}/share/applications/
+      - install -Dm644 app/linux/packaging/${FLATPAK_ID}.metainfo.xml -t ${FLATPAK_DEST}/share/metainfo/
+      - install -Dm644 assets/logo.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
     sources:
       - type: archive
         url: https://github.com/G-Ray/pikatorrent/releases/download/v0.15.0/PikaTorrent-v0.15.0-linux-x64.zip
@@ -127,8 +102,7 @@ modules:
           url: https://api.github.com/repos/G-Ray/pikatorrent/releases/latest
           version-query: .tag_name | sub("^v"; "")
           timestamp-query: .published_at
-          url-query:
-            .assets | map(.browser_download_url | select(endswith("-linux-x64.zip")))
+          url-query: .assets | map(.browser_download_url | select(endswith("-linux-x64.zip")))
             | first
 
       - type: archive
@@ -143,48 +117,13 @@ modules:
           url: https://api.github.com/repos/G-Ray/pikatorrent/releases/latest
           version-query: .tag_name | sub("^v"; "")
           timestamp-query: .published_at
-          url-query:
-            .assets | map(.browser_download_url | select(endswith("-linux-arm64.zip")))
+          url-query: .assets | map(.browser_download_url | select(endswith("-linux-arm64.zip")))
             | first
 
-      - type: file
-        dest-filename: com.pikatorrent.PikaTorrent.metainfo.xml
-        url: https://raw.githubusercontent.com/G-Ray/pikatorrent/v0.15.0/app/linux/packaging/com.pikatorrent.PikaTorrent.metainfo.xml
-        sha256: 1bf721a44ec1b54081bd4110df4df4a19f25deed7fe0b3a0d84bfab31780296b
+      - type: git
+        url: https://github.com/G-Ray/pikatorrent
+        tag: v0.15.0
+        commit: 7570685471c1f584c123eeba553dc38e033beb73
         x-checker-data:
-          type: json
-          url: https://api.github.com/repos/G-Ray/pikatorrent/releases/latest
-          tag-query: .tag_name
-          version-query: .tag_name | sub("^v"; "")
-          timestamp-query: .published_at
-          url-query:
-            '"https://raw.githubusercontent.com/G-Ray/pikatorrent/" + $tag
-            + "/app/linux/packaging/com.pikatorrent.PikaTorrent.metainfo.xml"'
-
-      - type: file
-        dest-filename: com.pikatorrent.PikaTorrent.desktop
-        url: https://raw.githubusercontent.com/G-Ray/pikatorrent/v0.15.0/app/linux/packaging/com.pikatorrent.PikaTorrent.desktop
-        sha256: 4bd452e7a3382009c96ce731b4e3d38ffc570c778808b5979d0d1ecb9a1dfcfa
-        x-checker-data:
-          type: json
-          url: https://api.github.com/repos/G-Ray/pikatorrent/releases/latest
-          tag-query: .tag_name
-          version-query: .tag_name | sub("^v"; "")
-          timestamp-query: .published_at
-          url-query:
-            '"https://raw.githubusercontent.com/G-Ray/pikatorrent/" + $tag
-            + "/app/linux/packaging/com.pikatorrent.PikaTorrent.desktop"'
-
-      - type: file
-        dest-filename: icon.png
-        url: https://raw.githubusercontent.com/G-Ray/pikatorrent/v0.15.0/app/linux/packaging/icon.png
-        sha256: f59d0e72153051e9babea4889af24c8cf05a46e1cdb7ef26179ba24a62d63604
-        x-checker-data:
-          type: json
-          url: https://api.github.com/repos/G-Ray/pikatorrent/releases/latest
-          tag-query: .tag_name
-          version-query: .tag_name | sub("^v"; "")
-          timestamp-query: .published_at
-          url-query:
-            '"https://raw.githubusercontent.com/G-Ray/pikatorrent/" + $tag
-            + "/app/linux/packaging/icon.png"'
+          type: git
+          tag-pattern: ^v([\d.]+)$


### PR DESCRIPTION
- Update the runtime version to 25.08
- Use the FFMPEG module from runtime
- Improve cleanup commands to reduce the Flatpak size
- Organise modules based on dependencies
- Validate dependencies

The installed size was reduced from 76.3 MB to 44.0 MB.